### PR TITLE
fix: When creating the Log class, the Status Property parameter is no…

### DIFF
--- a/extentreports-dotnet-core/ExtentTest.cs
+++ b/extentreports-dotnet-core/ExtentTest.cs
@@ -152,7 +152,8 @@ namespace AventStack.ExtentReports
             Model.ExceptionInfoContext.Add(e);
             var evt = new Log(Model)
             {
-                ExceptionInfo = e
+                ExceptionInfo = e,
+                Status =  status
             };
             return AddLog(evt);
         }


### PR DESCRIPTION
fix: When creating the Log class, the Status Property parameter is not set

Body: 
When creating the Log class in the Log (Status status, Exception ex, MediaEntityModelProvider provider = null) method, the Status property parameter was not set. Therefore, the state does not change.

Add state = state.
Line 155 of ExtentTest.cs
` 

```
 public ExtentTest Log(Status status, Exception ex, MediaEntityModelProvider provider = null)
  {
            ExceptionInfo e = new ExceptionInfo(ex);
            Model.ExceptionInfoContext.Add(e);
            var evt = new Log(Model)
            {
                ExceptionInfo = e,
                Status =  status   -> add this line
            };
            return AddLog(evt);
  }
```

`



Resolves: #89