### PR TITLE
Improve error message when upload file fails

### DIFF
--- a/extentreports-dotnet-core/MediaStorage/KlovHttpMediaManager.cs
+++ b/extentreports-dotnet-core/MediaStorage/KlovHttpMediaManager.cs
@@ -81,7 +81,8 @@ namespace AventStack.ExtentReports.MediaStorage
 
                         if (result.StatusCode != HttpStatusCode.OK)
                         {
-                            throw new IOException("Unable to upload file to server: " + m.Path);
+                            var fullResponseMessage = result.Content.ReadAsStringAsync().Result;
+                            throw new IOException($"Unable to upload file to server: {m.Path}. Response code: {result.StatusCode}. Full response: {fullResponseMessage}");
                         }
                     }
                 }


### PR DESCRIPTION
In order to make it easier to diagnose problems when trying to upload media files, I added the full response information to the exception. (Currently I get this exception but has no clue what's the root cause)