### PR TITLE
fix: ExtentTest Log Method is not set Status

### DIFF
--- a/extentreports-dotnet-core/ExtentTest.cs
+++ b/extentreports-dotnet-core/ExtentTest.cs
@@ -152,6 +152,7 @@ namespace AventStack.ExtentReports
             Model.ExceptionInfoContext.Add(e);
             var evt = new Log(Model)
             {
+                Status = status,
                 ExceptionInfo = e
             };
             return AddLog(evt);


### PR DESCRIPTION
FIxed: #89

More detailed
Log(Status status, Exception ex, MediaProvider provider = null) Mehtod

Do not set the status value. Therefore, the status value is always success.

