### PR TITLE
Fixed potential race condition

### DIFF
--- a/ExtentReports/Core/MediaEntityBuilder.cs
+++ b/ExtentReports/Core/MediaEntityBuilder.cs
@@ -8,7 +8,7 @@ namespace AventStack.ExtentReports
     {
         private static readonly string Base64Encoded = "data:image/png;base64,";
         private static readonly MediaEntityBuilder _instance = new MediaEntityBuilder();
-        private static ThreadLocal<Media> _media;
+        private static ThreadLocal<Media> _media = new ThreadLocal<Media>();
 
         public Media Build()
         {
@@ -19,10 +19,7 @@ namespace AventStack.ExtentReports
         {
             Assert.NotEmpty(path, "ScreenCapture path must not be null or empty");
 
-            _media = new ThreadLocal<Media>
-            {
-                Value = new ScreenCapture(path, title)
-            };
+            _media.Value = new ScreenCapture(path, title);
             return _instance;
         }
 
@@ -40,12 +37,9 @@ namespace AventStack.ExtentReports
                 base64 = Base64Encoded + base64;
             }
 
-            _media = new ThreadLocal<Media>
+            _media.Value = new ScreenCapture(null, title)
             {
-                Value = new ScreenCapture(null, title)
-                {
-                    Base64 = base64
-                }
+                Base64 = base64
             };
 
             return _instance;


### PR DESCRIPTION
The use of `ThreadLocal<T>` in `MediaEntityBuilder` looks wrong and can cause race conditions. A `ThreadLocal<T>` object should be initialized once, and only its `Value` property should be set in order to change the value per thread. Re-setting the reference to the `ThreadLocal<T>` object itself replaces the existing values for all threads.