### PR TITLE
Change log timestamp render format to "HH:mm:ss.fff"

### DIFF
--- a/ExtentReports/Views/Spark/Partials/Log.cshtml
+++ b/ExtentReports/Views/Spark/Partials/Log.cshtml
@@ -16,7 +16,7 @@
       var status = log.Status.ToString().ToLower();
       <tr class="event-row">
         <td><span class="badge log @status-bg">@log.Status</span></td>
-        <td>@log.Timestamp.ToShortTimeString()</td>
+        <td>@log.Timestamp.ToString("HH:mm:ss.fff")</td>
         <td>
           @if (log.HasException)
           { 


### PR DESCRIPTION
Currently log timestamp is rendered in a short time format, like "9:12 AM", which is not very informative. Usually test steps took milliseconds, sometimes seconds. And it is useful to see the time difference between particular steps. So I propose to render timestamp with "HH:mm:ss.fff" format. For example, "9:12 AM" becomes something like "09:12:45.125".