### PR TITLE
Remove cdn.rawgit links (see description for context)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ KlovReporter/bin/
 KlovReporter/obj/
 extentreports-dotnet-core/
 extentreports-dotnet-core/obj/
+Runner/
 pkg/

--- a/ExtentReports/Views/Spark/Partials/Head.cshtml
+++ b/ExtentReports/Views/Spark/Partials/Head.cshtml
@@ -22,7 +22,7 @@
  <link rel="shortcut icon" href="https://@iconURI/commons/img/logo.png">
  <link href="https://@cssURI/spark/css/spark-style.css" rel="stylesheet" />
  <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
- <script src="https://cdn.rawgit.com/extent-framework/extent-github-cdn/7cc78ce/spark/js/jsontree.js"></script>
+ <script src="https://@cssURI/spark/js/jsontree.js"></script>
  }
  <style>@Model.Config.CSS</style>
 </head>


### PR DESCRIPTION
https://news.ycombinator.com/item?id=18202481

jsontree.js was being referenced via `cdn.rawgit` which failed to return a valid js file.  

https://github.com/extent-framework/extentreports-csharp/issues/216