### PR TITLE
Use v4 run duration format

### DIFF
--- a/ExtentReports/Model/Test.cs
+++ b/ExtentReports/Model/Test.cs
@@ -86,7 +86,9 @@ namespace AventStack.ExtentReports.Model
             }
         }
 
-        public double TimeTaken => EndTime.Subtract(StartTime).TotalMilliseconds;
+        public TimeSpan RunDuration => EndTime.Subtract(StartTime);
+
+        public double TimeTaken => RunDuration.TotalMilliseconds;
 
         public bool IsBdd => BddType != null;
 

--- a/ExtentReports/Views/Spark/Partials/SparkTestSPA.cshtml
+++ b/ExtentReports/Views/Spark/Partials/SparkTestSPA.cshtml
@@ -75,7 +75,7 @@
           <div class="test-detail">
             <p class="name">@test.Name</p>
             <p class="text-sm">
-              <span>@test.StartTime.ToLongTimeString()</span> / <span>@timeTaken ms</span>
+              <span>@test.StartTime.ToLongTimeString()</span> / <span>@timeTaken.ToString("''h'h:'m'm:'s's+'fff'ms'")</span>
               <span class="badge @status-bg log float-right">@test.Status</span>
             </p>
           </div>

--- a/ExtentReports/Views/Spark/Partials/SparkTestSPA.cshtml
+++ b/ExtentReports/Views/Spark/Partials/SparkTestSPA.cshtml
@@ -62,7 +62,6 @@
         @foreach (var test in testList)
         {
         var reporterTest = new SparkReporterTest(Model, test);
-        var timeTaken = Math.Round(test.TimeTaken, 2);
         var status = test.Status.ToString().ToLower();
         var authors = ""; var tags = ""; var devices = "";
         foreach (var x in test.Author) { authors += x.Name + " "; }
@@ -75,7 +74,7 @@
           <div class="test-detail">
             <p class="name">@test.Name</p>
             <p class="text-sm">
-              <span>@test.StartTime.ToLongTimeString()</span> / <span>@timeTaken.ToString("''h'h:'m'm:'s's+'fff'ms'")</span>
+              <span>@test.StartTime.ToLongTimeString()</span> / <span>@test.RunDuration.ToString("''h'h:'m'm:'s's+'fff'ms'")</span>
               <span class="badge @status-bg log float-right">@test.Status</span>
             </p>
           </div>
@@ -86,7 +85,7 @@
                   <h5 class="test-status text-@status">@test.Name</h5>
                   <span class='badge badge-success'>@test.StartTime</span>
                   <span class='badge badge-danger'>@test.EndTime</span>
-                  <span class='badge badge-default'>@timeTaken ms</span>
+                  <span class='badge badge-default'>@test.RunDuration.ToString("''h'h:'m'm:'s's+'fff'ms'")</span>
                   &middot; <span class='uri-anchor badge badge-default'>#test-id=@test.Id</span>
                   <span title='Skip to the next failed step' class='badge badge-danger pointer float-right ne ml-1'><i class="fa fa-fast-forward"></i></span>
                   <span title='Collapse all nodes' class='badge badge-default pointer float-right ct ml-1'><i class="fa fa-compress"></i></span>


### PR DESCRIPTION
#218 

Version 4 had a cleaner representation of time taken for test:

```
<p class="duration text-sm">@test.RunDuration.ToString("''h'h:'m'm:'s's+'fff'ms'")</p> 
<span class="datetime">@test.StartTime.ToString("HH:mm:ss tt")</span>
```

Current version (5.0.4) shows it as following: `<span>@timeTaken ms</span>` where `timeTaken = Math.Round(test.TimeTaken, 2);`.