### PR TITLE
Fixes #220 - Duplicate graph in Dashboard when Analysis.Strategy = Test

### DIFF
--- a/ExtentReports/Views/Spark/Partials/SparkDashboardSPA.cshtml
+++ b/ExtentReports/Views/Spark/Partials/SparkDashboardSPA.cshtml
@@ -8,7 +8,8 @@
 
   var chartsCount = 2;
   chartsCount = Model.Report.Stats.SumStat(Model.Report.Stats.Child) > 0 ? 3 : chartsCount;
-  chartsCount = Model.Report.Stats.SumStat(Model.Report.Stats.Grandchild) > 0 ? 4 : chartsCount;
+  chartsCount = Model.Report.AnalysisStrategy == AnalysisStrategy.BDD && 
+    Model.Report.Stats.SumStat(Model.Report.Stats.Grandchild) > 0 ? 4 : chartsCount;
 
   var bdd = testList[0].IsBdd;
   var boxSize = "col-md-" + (12/chartsCount);
@@ -116,7 +117,7 @@
       </div>
     </div>
     }
-    @if (Model.Report.Stats.SumStat(Model.Report.Stats.Grandchild) > 0) {
+    @if (Model.Report.AnalysisStrategy == AnalysisStrategy.BDD && Model.Report.Stats.SumStat(Model.Report.Stats.Grandchild) > 0) {
     <div class="@boxSize">
       <div class="card">
         <div class="card-header">


### PR DESCRIPTION
Prior to this fix, the following code results in an extra chart due to a bug which considers 3 levels when `AnalysisStrategy == [Test, Class]`.  

```cs
using AventStack.ExtentReports;
using AventStack.ExtentReports.Reporter;

var extent = new ExtentReports();
extent.AttachReporter(new ExtentSparkReporter("index.html"));
extent.CreateTest("Test").CreateNode("Node").CreateNode("Node").Pass();
extent.Flush();
```

This should not be the case, unless the analysis occurs for BDD/Specflow type instances where there are indeed 3 levels of tests:

```
- Feature
  - Scenario
    - Step
      - Log (optional) (reported under log events instead of test)
```

Before:

![image](https://github.com/extent-framework/extentreports-csharp/assets/4107384/9cb65a1d-d3f5-438b-84f2-08454b56db57)

After:

![image](https://github.com/extent-framework/extentreports-csharp/assets/4107384/afcc1741-98f6-4dec-9723-13309ce806c9)
